### PR TITLE
Updates before 1.8

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -7,7 +7,7 @@ Release candidate for pyControl version 1.8.
 
 GUI:
 
-- GUI is now compatible with PyQt 6 and Python 3.10.
+- GUI is now compatible with PyQt6 and Python 3.10.
 
 - New GUI settings dialog.
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,7 +1,7 @@
 # Release Notes
 [Releases on GitHub](https://github.com/pyControl/code/releases)
 
-## Version 1.8rc1 --- 07/10/2022
+## Version 1.8rc1 (2022-10-07)
 
 Release candidate for pyControl version 1.8.
 
@@ -35,7 +35,7 @@ Data import:
 
 ---
 
-## Version 1.7.2 --- 30/06/2022
+## Version 1.7.2 (2022-06-30)
 
 GUI:
 
@@ -50,7 +50,7 @@ GUI:
 
 ---
 
-## Version 1.7.1 --- 20/04/2022
+## Version 1.7.1 (2022-04-20)
 
 GUI:
 
@@ -58,7 +58,7 @@ GUI:
 
 ---
 
-## Version 1.7 --- 06/04/2022
+## Version 1.7 (2022-04-06)
 
 GUI:
 
@@ -72,7 +72,7 @@ Tools:
 
 ---
 
-## Version 1.6.2 --- 23/12/2021
+## Version 1.6.2 (2021-12-23)
 
 !!! note "Note"
     **You will need to reload the framework onto your pyboards** (using the board config menu) after updating the GUI to this release, due to changes in the communication protocol between the board and the GUI.
@@ -85,7 +85,7 @@ Framework:
 
 ---
 
-## Version 1.6.1 --- 22/11/2021
+## Version 1.6.1 (2021-11-22)
 
 !!! note "Note"
     **You will need to reload the framework onto your pyboards** (using the board config menu) after updating the GUI to this release, due to changes in the communication protocol between the board and the GUI.
@@ -107,7 +107,7 @@ GUI:
 
 ---
 
-## Version 1.6 --- 25/11/2020
+## Version 1.6 (2020-11-25)
 GUI: 
 
 - Experiments that use multiple setups now load the task in parallel on all the setups at once, rather than serially on one setup after annother, giving a large speedup when many setups are used.
@@ -122,7 +122,7 @@ GUI:
 
 ---
 
-## Version 1.5 --- 11/02/2020
+## Version 1.5 (2020-02-11)
 GUI: 
 
 - Task files used in an experiment are now automatically saved in the experiments data folder with a file hash appended to the task file name to uniquely identify the file version.  Whenever a task file used in the experiment is modified the new version will be saved to the data folder when the experiment is run.  The task file hash used for each session is recorded in the session's data file so the exact task file used to run each session can be identified.
@@ -155,7 +155,7 @@ CLI:
 
 ---
 
-## Version 1.4 --- 03/02/2019
+## Version 1.4 (2019-02-03)
 
 GUI: 
 
@@ -167,7 +167,7 @@ Tools:
 
 ---
 
-## Version 1.3.3 --- 12/12/2018
+## Version 1.3.3 (2018-12-12)
 
 
 GUI:
@@ -186,7 +186,7 @@ Tools:
 
 ---
 
-## Version 1.3.2 --- 27/07/2018
+## Version 1.3.2 (2018-07-27)
 
 CLI/GUI:
 
@@ -202,7 +202,7 @@ Tools:
 
 ---
 
-## Version 1.3.1 --- 16/05/2018
+## Version 1.3.1 (2018-05-16)
 
 GUI: 
 
@@ -214,7 +214,7 @@ Framework:
 
 ---
 
-## Version 1.3 --- 16/04/2018
+## Version 1.3 (2018-04-16)
 
 GUI: 
 
@@ -237,7 +237,7 @@ Framework:
 
 ---
 
-## Version 1.2.1 --- 29/03/2018
+## Version 1.2.1 (2018-03-29)
 
 CLI:
 
@@ -250,7 +250,7 @@ Framework:
 
 ---
 
-## Version 1.2 --- 31/01/2018
+## Version 1.2 (2018-01-31)
 
 CLI:
 
@@ -268,7 +268,7 @@ Framework:
 
 ---
 
-## Version 1.1.4 --- 21/12/2017
+## Version 1.1.4 (2017-12-21)
 
 Framework:
 
@@ -285,7 +285,7 @@ Bug fixes:
 
 ---
 
-## Version 1.1.3 --- 28/07/2017
+## Version 1.1.3 (2017-07-28)
 
 - Added data_import.py, a module for importing pyControl sessions and experiments
    into Python for analysis. 
@@ -306,7 +306,7 @@ Bug fixes:
 
 ---
 
-## Version 1.1.2 ---  08/05/2017
+## Version 1.1.2 (2017-05-08)
 
 Framework:
 
@@ -335,7 +335,7 @@ Bug fixes:
 
 ---
 
-## Version 1.1 --- 06/02/2017
+## Version 1.1 (2017-02-06)
 
 
 Framework:
@@ -350,6 +350,6 @@ CLI:
 
 ---
 
-## Version 1.0 --- 30/12/2016
+## Version 1.0 (2016-12-30)
 
 - Initial release of pyControl CLI

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,15 +1,12 @@
 # Contributing to pyControl
 
-The pyControl project welcomes contributions from developers and
-users in the open source community. Contributions can be made in a number of ways, including:
+The pyControl project welcomes contributions from users and developers in the open source community. Contributions can be made in a number of ways, including:
 
-- Code patches via pull requests
+- Sharing the project
+- Asking questions or making suggestions in the [Discussions](link)
 - Documentation improvements
 - Bug reports and patch reviews
-
-To get started improving pyControl, fork the relevant pyControl repository on [GitHub](https://github.com/pyControl).
-
-The default branch of the repository contains the last numbered release. The dev branch contains the latest version which typically has more features but may be more buggy. pyControl development should build on the latest commit in the dev branch to facilitate integrating it back into the codebase.
+- Code patches via pull requests
 
 ## Reporting an Issue
 
@@ -19,6 +16,18 @@ Please include as much detail as you can. Let us know your platform and pyContro
 - [hardware issues](https://github.com/pyControl/hardware/issues)
 - [documentation issues](https://github.com/pyControl/docs/issues)
 
+## Increasing project visibility
+
+Spreading the word about pyControl helps maximize the number of people that benefit from this work.
+Additionally, increasing users should lead to more feedback, suggestions, and code contributions that will ultimately improve the software for everyone.
+If you have found pyControl useful, consider starring the [code repository on GitHub](https://github.com/pyControl/code) and/or sharing your experience with others.
+
 ## Submitting Pull Requests
+
+To get started developing for pyControl, fork the relevant pyControl repository on [GitHub](https://github.https://github.com/pyControl/code/pyControl).
+
+The default branch of the repository contains the last numbered release.
+The dev branch contains the latest version which typically has more features but may be more buggy.
+pyControl development should build on the latest commit in the dev branch to facilitate integrating it back into the codebase.
 
 Once you are happy with your changes, or you are ready for some feedback, push it to your fork and send a pull request.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs==1.3.0
+mkdocs==1.4.0
 jinja2==3.1.2


### PR DESCRIPTION
- changed the date format since I read dates such as 06/04/2022 as June 4th 2022 while British folks and the docs are referring to April 6th 2022. I think using the [international format](https://en.wikipedia.org/wiki/ISO_8601) avoids the confusion, hopefully making American and British date readers equally unhappy 😁 
- Added some text about contributing to the project through sharing/promoting pyControl. Feel free to reword or remove if it seems out of place. Although I do think we should try to do a better job at promoting the project.
- might as well keep up to date with the latest mkdocs version